### PR TITLE
Implement local parser for vacancy fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -1400,8 +1400,28 @@ document.addEventListener('DOMContentLoaded', () => {
         elementos.searchResults.classList.remove('hidden');
     }
     
+    function parseLocally(text) {
+        const sections = {
+            requisitos: /(?:requisitos?|pr[eé]-?requisitos?)\s*:?\s*([\s\S]*?)(?=(benef[ií]cios?|turno|hor[áa]rio|notas|informa\u00e7\u00f5es|$))/i,
+            beneficios: /benef[ií]cios?\s*:?\s*([\s\S]*?)(?=(requisitos?|pr[eé]-?requisitos?|turno|hor[áa]rio|notas|informa\u00e7\u00f5es|$))/i,
+            turno: /(turno|hor[áa]rio)\s*:?\s*([\s\S]*?)(?=(requisitos?|pr[eé]-?requisitos?|benef[ií]cios?|notas|informa\u00e7\u00f5es|$))/i,
+            notas: /(notas|informa\u00e7\u00f5es adicionais?)\s*:?\s*([\s\S]*?)(?=(requisitos?|pr[eé]-?requisitos?|benef[ií]cios?|turno|hor[áa]rio|$))/i
+        };
+        const result = { requisitos: '', beneficios: '', turno: '', notas: '' };
+        for (const [key, regex] of Object.entries(sections)) {
+            const match = text.match(regex);
+            if (match) {
+                result[key] = (match[1] || match[2] || '').trim();
+            }
+        }
+        return result;
+    }
+
     async function parseWithGemini(text) {
-        const apiKey = ""; 
+        const apiKey = "";
+        if (!apiKey) {
+            return parseLocally(text);
+        }
         
         let timerInterval;
         Swal.fire({
@@ -1455,11 +1475,16 @@ document.addEventListener('DOMContentLoaded', () => {
             if (progressBar) progressBar.style.width = '100%';
             const candidate = result.candidates?.[0];
             const content = candidate?.content?.parts?.[0]?.text;
-            return content ? JSON.parse(content) : null;
+            if (!content) return null;
+            try {
+                return JSON.parse(content);
+            } catch (_) {
+                return parseLocally(content);
+            }
 
         } catch (error) {
             Swal.close();
-            return null;
+            return parseLocally(text);
         }
     }
 


### PR DESCRIPTION
## Summary
- add `parseLocally` function to parse vacancy descriptions without the API
- fallback to local parser when the Gemini request fails or the API key is missing
- attempt JSON parsing of Gemini response and use local parser on failure

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c29b042dc832f89c64ac4b5a03076